### PR TITLE
[서버] login api 호출 시 클라이언트로 redirect되게 변경

### DIFF
--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -113,8 +113,8 @@ class AuthController {
       // console.log(redirectURI);
       // res.redirect('https://real-todolist.vercel.app');
       const tokenData = this.createToken(loginUser);
-
-      res.status(200).json({ token: tokenData, user: loginUser });
+      res.set('token', tokenData.token);
+      res.redirect(this.redirectURI);
     } catch (error) {
       next(error);
     }


### PR DESCRIPTION
- 호출시 클라이언트로 redirect
- 토큰 데이터를 `token` Header에 넣어 res로 전달